### PR TITLE
fix dlang link to dlang.org

### DIFF
--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,4 +1,4 @@
-[D](https://en.wikipedia.org/wiki/D_(programming_language) is a systems programming language with
+[D](https://dlang.org) is a systems programming language with
 C-like syntax and static typing. It combines efficiency, control and modeling power with safety
 and programmer productivity. The language was developed originally by [Walter Bright]
 (https://en.wikipedia.org/wiki/Walter_Bright) and [Andrei


### PR DESCRIPTION
It has the advantage of not needing to figure out how to properly escape `)` in markdown ;-)