### PR TITLE
Add missing slug to exercises key in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -179,6 +179,11 @@
       "slug": "circular-buffer" ,
       "difficulty": 1,
       "topics": []
+    },
+    {
+      "slug": "pangram" ,
+      "difficulty": 1,
+      "topics": []
     }
   ],
   "deprecated": [


### PR DESCRIPTION
I updated the `configlet` tool which lints Exercism tracks so that it uses the "exercises" rather than the (now deprecated) "problems" key.
