### PR TITLE
travis: test all exercises 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 ---
 language: bash
-script:
+install:
 - bin/fetch-configlet
+script:
 - bin/configlet .
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 ---
-language: bash
+language: d
 install:
 - bin/fetch-configlet
 script:
 - bin/configlet .
+- bin/test-all-exercises
 sudo: false

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Exercism exercises in the D Programming Language
 
+[![Build Status](https://travis-ci.org/exercism/xdlang.svg?branch=master)](https://travis-ci.org/exercism/xdlang)
+
 ## Filenames
 
 Each exercise is identified by a slug.

--- a/bin/test-all-exercises
+++ b/bin/test-all-exercises
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+test_one=$(dirname $0)/test-exercise
+exercises=$(dirname $(dirname $0))/exercises
+status=0
+failed_exercises=""
+
+for d in $exercises/*/; do
+  if ! $test_one $d; then
+    failed_exercises="$failed_exercises\n$(basename $d)"
+    status=1
+  fi
+done
+
+if [ $status -ne 0 ]; then
+  echo "The following exercises failed"
+  echo $failed_exercises
+fi
+
+exit $status

--- a/bin/test-exercise
+++ b/bin/test-exercise
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+if [ $# -eq 0 ]; then
+  echo "usage: $0 exercise-slug"
+  exit 1
+fi
+
+dir=$1
+exercise=$(basename $dir)
+underscored=$(echo "$exercise" | tr - _)
+example="${underscored}_example"
+backupext=testbak
+
+cd $dir
+
+dmd ${example}.d -de -w -unittest && ./$example

--- a/exercises/difference-of-squares/difference_of_squares.d
+++ b/exercises/difference-of-squares/difference_of_squares.d
@@ -1,9 +1,10 @@
 module difference_of_squares;
 
-import std.stdio;
+unittest {
+const int allTestsEnabled = 0;
 
-void main() {
     assert(squares(5).squareOfSum == 225);
+static if (allTestsEnabled) {
     assert(squares(10).squareOfSum == 3_025);
     assert(squares(100).squareOfSum == 25_502_500);
 
@@ -15,6 +16,8 @@ void main() {
     assert(squares(5).difference == 170);
     assert(squares(10).difference == 2_640);
     assert(squares(100).difference == 25_164_150);
-
-    writeln("All tests passed");
 }
+
+}
+
+void main() {}

--- a/exercises/difference-of-squares/difference_of_squares_example.d
+++ b/exercises/difference-of-squares/difference_of_squares_example.d
@@ -25,3 +25,20 @@ struct Squares {
 Squares squares(uint max) pure {
     return Squares(max);
 }
+
+unittest {
+    assert(squares(5).squareOfSum == 225);
+    assert(squares(10).squareOfSum == 3_025);
+    assert(squares(100).squareOfSum == 25_502_500);
+
+    assert(squares(5).sumOfSquares == 55);
+    assert(squares(10).sumOfSquares == 385);
+    assert(squares(100).sumOfSquares == 338_350);
+
+    assert(squares(0).difference == 0);
+    assert(squares(5).difference == 170);
+    assert(squares(10).difference == 2_640);
+    assert(squares(100).difference == 25_164_150);
+}
+
+void main () {}

--- a/exercises/gigasecond/gigasecond.d
+++ b/exercises/gigasecond/gigasecond.d
@@ -1,10 +1,12 @@
 module gigasecond;
 
-import std.stdio;
 import std.datetime;
 
-void main() {
+unittest {
+const int allTestsEnabled = 0;
+
     assert(gsAnniversary(DateTime(2011, 4, 25)) == DateTime(2043, 1, 1, 1, 46, 40));
+static if (allTestsEnabled) {
     assert(gsAnniversary(DateTime(1977, 6, 13)) == DateTime(2009, 2, 19, 1, 46, 40));
     assert(gsAnniversary(DateTime(1959, 7, 19)) == DateTime(1991, 3, 27, 1, 46, 40));
     assert(gsAnniversary(DateTime(2015, 1, 24, 22, 0, 0)) == DateTime(2046, 10, 2, 23, 46, 40));
@@ -16,6 +18,8 @@ void main() {
     assert(d == DateTime(2011, 4, 25));
 
     //For fun add a test for your own gigasecond anniversary
-
-    writeln("All tests pass");
 }
+
+}
+
+void main() {}

--- a/exercises/gigasecond/gigasecond_example.d
+++ b/exercises/gigasecond/gigasecond_example.d
@@ -8,3 +8,18 @@ enum Gigasecond = seconds(10^^9);
 DateTime gsAnniversary(in DateTime start) pure {
     return start + Gigasecond;
 }
+
+unittest {
+    assert(gsAnniversary(DateTime(2011, 4, 25)) == DateTime(2043, 1, 1, 1, 46, 40));
+    assert(gsAnniversary(DateTime(1977, 6, 13)) == DateTime(2009, 2, 19, 1, 46, 40));
+    assert(gsAnniversary(DateTime(1959, 7, 19)) == DateTime(1991, 3, 27, 1, 46, 40));
+    assert(gsAnniversary(DateTime(2015, 1, 24, 22, 0, 0)) == DateTime(2046, 10, 2, 23, 46, 40));
+    assert(gsAnniversary(DateTime(2015, 1, 24, 23, 59, 59)) == DateTime(2046, 10, 3, 1, 46, 39));
+
+    //check that it doesn't mutate the argument
+    auto d = DateTime(2011, 4, 25);
+    assert(gsAnniversary(d) == DateTime(2043, 1, 1, 1, 46, 40));
+    assert(d == DateTime(2011, 4, 25));
+}
+
+void main () {}

--- a/exercises/hello-world/hello_world.d
+++ b/exercises/hello-world/hello_world.d
@@ -1,12 +1,13 @@
 module helloworld_test;
 
-import std.stdio;
+unittest {
+const int allTestsEnabled = 0;
 
-void main() {
     assert(hello() == "Hello, World!");
+static if (allTestsEnabled) {
     assert(hello("Alice") == "Hello, Alice!");
     assert(hello("Bob") == "Hello, Bob!");
     assert(hello("") == "Hello, !");
+}
 
-    writeln("All tests passed.");
 }

--- a/exercises/hello-world/hello_world_example.d
+++ b/exercises/hello-world/hello_world_example.d
@@ -5,3 +5,12 @@ import std.format;
 string hello(const char[] name = "World") {
     return format("Hello, %s!", name);
 }
+
+unittest {
+    assert(hello() == "Hello, World!");
+    assert(hello("Alice") == "Hello, Alice!");
+    assert(hello("Bob") == "Hello, Bob!");
+    assert(hello("") == "Hello, !");
+}
+
+void main () {}

--- a/exercises/raindrops/raindrops.d
+++ b/exercises/raindrops/raindrops.d
@@ -1,7 +1,8 @@
-import std.stdio;
+unittest {
+const int allTestsEnabled = 0;
 
-void main() {
     assert(convert(1) == "1");
+static if (allTestsEnabled) {
     assert(convert(3) == "Pling");
     assert(convert(5) == "Plang");
     assert(convert(7) == "Plong");
@@ -16,6 +17,8 @@ void main() {
     assert(convert(49) == "Plong");
     assert(convert(52) == "52");
     assert(convert(105) == "PlingPlangPlong");
-
-    writeln("All tests passed");
 }
+
+}
+
+void main() {}

--- a/exercises/raindrops/raindrops_example.d
+++ b/exercises/raindrops/raindrops_example.d
@@ -33,3 +33,23 @@ private bool isPlang(int n) {
 private bool isPlong(int n) {
     return n % 7 == 0;
 }
+
+unittest {
+    assert(convert(1) == "1");
+    assert(convert(3) == "Pling");
+    assert(convert(5) == "Plang");
+    assert(convert(7) == "Plong");
+    assert(convert(6) == "Pling");
+    assert(convert(9) == "Pling");
+    assert(convert(10) == "Plang");
+    assert(convert(14) == "Plong");
+    assert(convert(15) == "PlingPlang");
+    assert(convert(21) == "PlingPlong");
+    assert(convert(25) == "Plang");
+    assert(convert(35) == "PlangPlong");
+    assert(convert(49) == "Plong");
+    assert(convert(52) == "52");
+    assert(convert(105) == "PlingPlangPlong");
+}
+
+void main () {}

--- a/exercises/rna-transcription/rna_transcription.d
+++ b/exercises/rna-transcription/rna_transcription.d
@@ -1,10 +1,12 @@
 module rna_transcription;
 
 import std.exception : assertThrown;
-import std.stdio;
 
-void main() {
+unittest {
+const int allTestsEnabled = 0;
+
     assert(dnaComplement("C") == "G");
+static if (allTestsEnabled) {
     assert(dnaComplement("G") == "C");
     assert(dnaComplement("T") == "A");
     assert(dnaComplement("A") == "U");
@@ -14,6 +16,8 @@ void main() {
     assertThrown(dnaComplement("U"));
     assertThrown(dnaComplement("XXX"));
     assertThrown(dnaComplement("ACGTXXXCTTAA"));
-
-    writeln("All tests passed");
 }
+
+}
+
+void main() {}

--- a/exercises/rna-transcription/rna_transcription_example.d
+++ b/exercises/rna-transcription/rna_transcription_example.d
@@ -20,3 +20,18 @@ string dnaComplement(string dna) {
     enforce(dna.matchFirst(dnaRegex), "Invalid DNA string");
     return dna.translate(rnaTransTable);
 }
+
+unittest {
+    assert(dnaComplement("C") == "G");
+    assert(dnaComplement("G") == "C");
+    assert(dnaComplement("T") == "A");
+    assert(dnaComplement("A") == "U");
+
+    assert(dnaComplement("ACGTGGTCTTAA") == "UGCACCAGAAUU");
+
+    assertThrown(dnaComplement("U"));
+    assertThrown(dnaComplement("XXX"));
+    assertThrown(dnaComplement("ACGTXXXCTTAA"));
+}
+
+void main () {}


### PR DESCRIPTION
this helps us ensure that our tests are solvable

To be able to achieve this, `main` had to be added to some exercises, as it would not compile without.

In consideration of #30 being a very large proposal, the Travis portion of that proposal has been extracted out into its own PR, so that it can be evaluated and merged separately.

Note that this PR necessarily differs in how it runs its tests, since it uses `dmd` instead of `dub test`, and it does require a `main` for each `.d` file (`dub test` does not). This can help contrast it with #30.

If this is merged before #30, I will have to rebase #30; I am prepared to do that.