### PR TITLE
fixed type issue

### DIFF
--- a/exercises/nucleotide-count/nucleotide_count.d
+++ b/exercises/nucleotide-count/nucleotide_count.d
@@ -10,7 +10,7 @@ unittest
 {
 
 // test associative array equality
-bool aaEqual (const int[char] lhs, const int[char] rhs)
+bool aaEqual (const ulong[char] lhs, const ulong[char] rhs)
 {
 	auto lhs_pairs = lhs.byKeyValue.array;
 	auto rhs_pairs = rhs.byKeyValue.array;


### PR DESCRIPTION
Hello,
I'm currently going through exercism D exercices and today I made the nucleotide_count one.
I noticed there was something wrong with the unit test. The aaEqual function requires ulong[char] parameters whereas the already written given test sends a int[char]. So as we know int can sometimes be passed as ulong but ulong can't be passed as an int. So I first checked other people answers and everyone had to mess around with the unit test to make it work. So I just changed the aaEqual parameters type to ulong instead of int so everything works.
Best regards.